### PR TITLE
Revert "local should allow for an empty array"

### DIFF
--- a/Typeahead.php
+++ b/Typeahead.php
@@ -101,7 +101,7 @@ class Typeahead extends TypeaheadBasic
     protected function validateConfig()
     {
         foreach ($this->dataset as $datum) {
-            if (!isset($datum['local']) && empty($datum['prefetch']) && empty($datum['remote'])) {
+            if (empty($datum['local']) && empty($datum['prefetch']) && empty($datum['remote'])) {
                 throw new InvalidConfigException("No data source found for the Typeahead. The 'dataset' array must have one of 'local', 'prefetch', or 'remote' settings enabled.");
             }
         }


### PR DESCRIPTION
Reverts kartik-v/yii2-widget-typeahead#1 - does not fix the issue
