### PR TITLE
Remove enforcement on empty arrays for widget

### DIFF
--- a/Typeahead.php
+++ b/Typeahead.php
@@ -89,7 +89,7 @@ class Typeahead extends TypeaheadBasic
      */
     public function run()
     {
-        if (empty($this->dataset) || !is_array($this->dataset)) {
+        if (!is_array($this->dataset)) {
             throw new InvalidConfigException("You must define the 'dataset' property for Typeahead which must be an array.");
         }
         if (!is_array(current($this->dataset))) {

--- a/TypeaheadBasic.php
+++ b/TypeaheadBasic.php
@@ -85,7 +85,7 @@ class TypeaheadBasic extends InputWidget
      */
     public function run()
     {
-        if (empty($this->data) || !is_array($this->data)) {
+        if (!is_array($this->data)) {
             throw new InvalidConfigException("You must define the 'data' property for Typeahead which must be a single dimensional array.");
         }
         $this->registerAssets();


### PR DESCRIPTION
 - fixes #25

## Scope
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
The following changes were made

- Removed the enforcement of an empty array on datasets/data

Because otherwise our view layer is cluttered with checking if the data is empty or not. We usually don't have any items to "typeahead" when none are in database. This means the widget fails to initialize making our view layer an if statement everywhere this is used checking if the typeahead data is empty.

## Related Issues
#25