### PR TITLE
Added .twitter-typeahead class to the input[readonly] selector

### DIFF
--- a/src/assets/css/typeahead-kv.css
+++ b/src/assets/css/typeahead-kv.css
@@ -19,7 +19,7 @@
 .tt-input.loading {
     background: transparent url('../img/loading.gif') no-repeat scroll right center content-box !important;
 }
-.twitter-typeahead input[disabled], input[readonly], fieldset[disabled] .twitter-typeahead input {
+.twitter-typeahead input[disabled], .twitter-typeahead input[readonly], fieldset[disabled] .twitter-typeahead input {
     background-color: #EEEEEE;
     cursor: not-allowed;
 }

--- a/src/assets/css/typeahead-kv.min.css
+++ b/src/assets/css/typeahead-kv.min.css
@@ -8,4 +8,4 @@
  * Copyright: 2014, Kartik Visweswaran, Krajee.com
  * For more JQuery plugins visit http://plugins.krajee.com
  * For more Yii related demos visit http://demos.krajee.com
- */.tt-scrollable-menu .tt-menu{max-height:140px;overflow-y:auto}.tt-rtl .tt-menu{text-align:right}.tt-input.loading{background:transparent url(../img/loading.gif) no-repeat scroll right center content-box!important}.twitter-typeahead input[disabled],fieldset[disabled] .twitter-typeahead input,input[readonly]{background-color:#EEE;cursor:not-allowed}
+ */.tt-scrollable-menu .tt-menu{max-height:140px;overflow-y:auto}.tt-rtl .tt-menu{text-align:right}.tt-input.loading{background:transparent url(../img/loading.gif) no-repeat scroll right center content-box!important}.twitter-typeahead input[disabled],fieldset[disabled] .twitter-typeahead input,.twitter-typeahead input[readonly]{background-color:#EEE;cursor:not-allowed}


### PR DESCRIPTION
Added .twitter-typeahead class to the input[readonly] selector to stop it from affecting unintended elements

## Scope
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
The following changes were made

- added the .twitter-typeahead class to the input[readonly] selector in the css file

## Related Issues
If this is related to an existing ticket, include a link to it as well.
Closes #45